### PR TITLE
Initialize kbtextstr on ctor

### DIFF
--- a/source/libwiigui/gui_keyboard.cpp
+++ b/source/libwiigui/gui_keyboard.cpp
@@ -35,6 +35,7 @@ GuiKeyboard::GuiKeyboard(char * t, u32 max)
 	focus = 0; // allow focus
 	alignmentHor = ALIGN_CENTRE;
 	alignmentVert = ALIGN_MIDDLE;
+	memset(kbtextstr, '\0', 255);
 	snprintf(kbtextstr, 255, "%s", t);
 	kbtextmaxlen = max;
 


### PR DESCRIPTION
This prevents garbage data from being inserted into the string when pressing the space bar on next keyboard instance 